### PR TITLE
fix crash when texture cannot be loaded

### DIFF
--- a/Plugins/ModoMaterialImporter/Source/ModoMaterialImporter/Public/ModoMaterialImporterTextureManager.cpp
+++ b/Plugins/ModoMaterialImporter/Source/ModoMaterialImporter/Public/ModoMaterialImporterTextureManager.cpp
@@ -120,7 +120,7 @@ UTexture* TextureManager::LoadTexture(const FString& TextureFilename, const FStr
 		}
 		else 
 		{
-			UE_LOG(ModoMaterialImporter, Log, TEXT("Texture '%s' fails to create"), *texAsset->GetName());
+			UE_LOG(ModoMaterialImporter, Log, TEXT("Texture '%s' fails to create"), *TextureFilename);
 		}
 
 	}


### PR DESCRIPTION
Instead of trying to access a member from a null pointer print the path of the texture to the errror log.
